### PR TITLE
feat: allow custom http.Client with default client

### DIFF
--- a/rtorrent.go
+++ b/rtorrent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/autobrr/go-rtorrent/xmlrpc"
@@ -49,6 +50,12 @@ func NewClient(cfg Config) *Client {
 	}
 
 	return c
+}
+
+// WithHTTPClient allows you to a provide a custom http.Client.
+func (r *Client) WithHTTPClient(client *http.Client) *Client {
+	r.xmlrpcClient = xmlrpc.NewClientWithHTTPClient(r.addr, client)
+	return r
 }
 
 // FieldValue contains the Field and Value of an attribute on a rTorrent

--- a/rtorrent_test.go
+++ b/rtorrent_test.go
@@ -2,7 +2,7 @@ package rtorrent
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -488,7 +488,7 @@ func TestRTorrent(t *testing.T) {
 		})
 
 		t.Run("with data", func(t *testing.T) {
-			b, err := ioutil.ReadFile("testdata/Fedora-i3-Live-x86_64-35.torrent")
+			b, err := os.ReadFile("testdata/Fedora-i3-Live-x86_64-35.torrent")
 			require.NoError(t, err)
 			require.NotEmpty(t, b)
 
@@ -562,7 +562,7 @@ func TestRTorrent(t *testing.T) {
 		})
 
 		t.Run("with data (stopped)", func(t *testing.T) {
-			b, err := ioutil.ReadFile("testdata/Fedora-i3-Live-x86_64-35.torrent")
+			b, err := os.ReadFile("testdata/Fedora-i3-Live-x86_64-35.torrent")
 			require.NoError(t, err)
 			require.NotEmpty(t, b)
 


### PR DESCRIPTION
This method seems to have been lost in the migration from `mrobinsn/go-rtorrent`.