### PR TITLE
Add delete methods

### DIFF
--- a/rtorrent.go
+++ b/rtorrent.go
@@ -524,6 +524,22 @@ func (r *Client) DeleteTied(ctx context.Context, t Torrent) error {
 	return nil
 }
 
+// SetForceDelete sets force delete flag
+func (r *Client) SetForceDelete(ctx context.Context, t Torrent, val bool) error {
+	var valStr string
+	if (val) {
+		valStr = "2"
+	} else {
+		valStr = "1"
+	}
+	
+	_, err := r.xmlrpcClient.Call(ctx, "d.set_custom5", t.Hash, valStr)
+	if err != nil {
+		return errors.Wrap(err, "d.set_custom5 (force delete) XMLRPC call failed")
+	}
+	return nil
+}
+
 // GetFiles returns all the files for a given `Torrent`
 func (r *Client) GetFiles(ctx context.Context, t Torrent) ([]File, error) {
 	args := []interface{}{t.Hash, 0, FPath.Query(), FSizeInBytes.Query()}

--- a/rtorrent.go
+++ b/rtorrent.go
@@ -533,9 +533,9 @@ func (r *Client) SetForceDelete(ctx context.Context, t Torrent, val bool) error 
 		valStr = "1"
 	}
 	
-	_, err := r.xmlrpcClient.Call(ctx, "d.set_custom5", t.Hash, valStr)
+	_, err := r.xmlrpcClient.Call(ctx, "d.custom5.set", t.Hash, valStr)
 	if err != nil {
-		return errors.Wrap(err, "d.set_custom5 (force delete) XMLRPC call failed")
+		return errors.Wrap(err, "d.custom5.set (force delete) XMLRPC call failed")
 	}
 	return nil
 }

--- a/rtorrent.go
+++ b/rtorrent.go
@@ -515,6 +515,15 @@ func (r *Client) Delete(ctx context.Context, t Torrent) error {
 	return nil
 }
 
+// DeleteTied removes the torrent files
+func (r *Client) DeleteTied(ctx context.Context, t Torrent) error {
+	_, err := r.xmlrpcClient.Call(ctx, "d.delete_tied", t.Hash)
+	if err != nil {
+		return errors.Wrap(err, "d.delete_tied XMLRPC call failed")
+	}
+	return nil
+}
+
 // GetFiles returns all the files for a given `Torrent`
 func (r *Client) GetFiles(ctx context.Context, t Torrent) ([]File, error) {
 	args := []interface{}{t.Hash, 0, FPath.Query(), FSizeInBytes.Query()}


### PR DESCRIPTION
Add implementation for `d.custom5.set` (SetForceDelete) and `d.delete_tied` (DeleteTied) methods.

These methods are responsible for removing data files from the hard drive.

[More details here](https://github.com/rakshasa/rtorrent/issues/862)